### PR TITLE
Disable the audio of Webcam component

### DIFF
--- a/src/web-ui/src/App.js
+++ b/src/web-ui/src/App.js
@@ -76,6 +76,7 @@ export default () => {
           <Row>
             <Col md={8} sm={6}>
               <Webcam
+                audio={false}
                 ref={setupWebcam}
                 screenshotFormat="image/jpeg"
                 videoConstraints={{


### PR DESCRIPTION
By default, the webcam component also uses audio from a microphone
This isn't required in the app, so it can be safely disabled.

*Issue #, if available:*
NA

*Description of changes:*
This PR removes the audio feed from the webcam component. The app doesn't need it, so we can safely remove it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
